### PR TITLE
:bug: Fix CQRS update version mismatch with hybrid LWW/rehydrate

### DIFF
--- a/adapter/src/processor/account.rs
+++ b/adapter/src/processor/account.rs
@@ -6,7 +6,7 @@ use kernel::interfaces::read_model::{AccountReadModel, DependOnAccountReadModel}
 use kernel::interfaces::signal::Signal;
 use kernel::prelude::entity::{
     Account, AccountId, AccountIsBot, AccountName, AccountPrivateKey, AccountPublicKey,
-    AuthAccountId, Nanoid,
+    AuthAccountId, EventVersion, Nanoid,
 };
 use kernel::KernelError;
 use std::future::Future;
@@ -25,7 +25,7 @@ pub struct CreateAccountParam {
 pub struct UpdateAccountParam {
     pub account_id: AccountId,
     pub is_bot: AccountIsBot,
-    pub current_version: kernel::prelude::entity::EventVersion<Account>,
+    pub current_version: EventVersion<Account>,
 }
 
 // --- Signal DI trait (adapter-specific) ---

--- a/adapter/src/processor/profile.rs
+++ b/adapter/src/processor/profile.rs
@@ -5,8 +5,7 @@ use kernel::interfaces::event_store::{DependOnProfileEventStore, ProfileEventSto
 use kernel::interfaces::read_model::{DependOnProfileReadModel, ProfileReadModel};
 use kernel::interfaces::signal::Signal;
 use kernel::prelude::entity::{
-    AccountId, EventVersion, FieldAction, ImageId, Nanoid, Profile, ProfileDisplayName, ProfileId,
-    ProfileSummary,
+    AccountId, FieldAction, ImageId, Nanoid, Profile, ProfileDisplayName, ProfileId, ProfileSummary,
 };
 use kernel::KernelError;
 use std::future::Future;
@@ -37,7 +36,6 @@ pub struct UpdateProfileParam {
     pub summary: FieldAction<ProfileSummary>,
     pub icon: FieldAction<ImageId>,
     pub banner: FieldAction<ImageId>,
-    pub current_version: EventVersion<Profile>,
 }
 
 // --- ProfileCommandProcessor ---
@@ -125,7 +123,6 @@ where
             param.summary,
             param.icon,
             param.banner,
-            param.current_version,
         );
 
         self.profile_event_store()

--- a/application/src/service/account.rs
+++ b/application/src/service/account.rs
@@ -14,13 +14,15 @@ use adapter::processor::profile::{
 use error_stack::Report;
 use kernel::interfaces::crypto::{DependOnPasswordProvider, PasswordProvider};
 use kernel::interfaces::database::DatabaseConnection;
+use kernel::interfaces::event::EventApplier;
+use kernel::interfaces::event_store::{AccountEventStore, DependOnAccountEventStore};
 use kernel::interfaces::permission::{
     AccountRelation, DependOnPermissionChecker, DependOnPermissionWriter, PermissionWriter,
     RelationTarget,
 };
 use kernel::prelude::entity::{
-    Account, AccountIsBot, AccountName, AccountPrivateKey, AccountPublicKey, AuthAccountId, Nanoid,
-    Profile, ProfileDisplayName,
+    Account, AccountId, AccountIsBot, AccountName, AccountPrivateKey, AccountPublicKey,
+    AuthAccountId, EventId, EventVersion, Nanoid, Profile, ProfileDisplayName,
 };
 use kernel::KernelError;
 use serde_json;
@@ -189,6 +191,7 @@ pub trait UpdateAccountUseCase:
     + Send
     + DependOnAccountCommandProcessor
     + DependOnAccountQueryProcessor
+    + DependOnAccountEventStore
     + DependOnPermissionChecker
 {
     fn update_account(
@@ -200,7 +203,7 @@ pub trait UpdateAccountUseCase:
             let mut transaction = self.database_connection().get_executor().await?;
 
             let nanoid = Nanoid::<Account>::new(dto.account_nanoid);
-            let account = self
+            let projection = self
                 .account_query_processor()
                 .find_by_nanoid_unfiltered(&mut transaction, &nanoid)
                 .await?
@@ -211,20 +214,29 @@ pub trait UpdateAccountUseCase:
                     ))
                 })?;
 
-            check_permission(self, auth_account_id, &account_edit(account.id())).await?;
+            check_permission(self, auth_account_id, &account_edit(projection.id())).await?;
+
+            let account_id = projection.id().clone();
+            let (account, current_version) =
+                rehydrate_account(self, &mut transaction, &account_id).await?;
 
             if !account.status().is_active() {
                 return Err(Report::new(KernelError::Rejected)
                     .attach_printable("Cannot modify a suspended or banned account"));
+            }
+            if account.deleted_at().is_some() {
+                return Err(
+                    Report::new(KernelError::Rejected).attach_printable("Account is deactivated")
+                );
             }
 
             self.account_command_processor()
                 .update(
                     &mut transaction,
                     UpdateAccountParam {
-                        account_id: account.id().clone(),
+                        account_id,
                         is_bot: AccountIsBot::new(dto.is_bot),
-                        current_version: account.version().clone(),
+                        current_version,
                     },
                 )
                 .await?;
@@ -238,6 +250,7 @@ impl<T> UpdateAccountUseCase for T where
     T: 'static
         + DependOnAccountCommandProcessor
         + DependOnAccountQueryProcessor
+        + DependOnAccountEventStore
         + DependOnPermissionChecker
 {
 }
@@ -248,6 +261,7 @@ pub trait DeactivateAccountUseCase:
     + Send
     + DependOnAccountCommandProcessor
     + DependOnAccountQueryProcessor
+    + DependOnAccountEventStore
     + DependOnPermissionChecker
     + DependOnPermissionWriter
 {
@@ -260,7 +274,7 @@ pub trait DeactivateAccountUseCase:
             let mut transaction = self.database_connection().get_executor().await?;
 
             let nanoid = Nanoid::<Account>::new(account_id);
-            let account = self
+            let projection = self
                 .account_query_processor()
                 .find_by_nanoid(&mut transaction, &nanoid)
                 .await?
@@ -271,10 +285,11 @@ pub trait DeactivateAccountUseCase:
                     ))
                 })?;
 
-            check_permission(self, auth_account_id, &account_deactivate(account.id())).await?;
+            check_permission(self, auth_account_id, &account_deactivate(projection.id())).await?;
 
-            let account_id = account.id().clone();
-            let current_version = account.version().clone();
+            let account_id = projection.id().clone();
+            let (_account, current_version) =
+                rehydrate_account(self, &mut transaction, &account_id).await?;
             self.account_command_processor()
                 .deactivate(&mut transaction, account_id.clone(), current_version)
                 .await?;
@@ -304,6 +319,7 @@ impl<T> DeactivateAccountUseCase for T where
     T: 'static
         + DependOnAccountCommandProcessor
         + DependOnAccountQueryProcessor
+        + DependOnAccountEventStore
         + DependOnPermissionChecker
         + DependOnPermissionWriter
 {
@@ -315,6 +331,7 @@ pub trait SuspendAccountUseCase:
     + Send
     + DependOnAccountCommandProcessor
     + DependOnAccountQueryProcessor
+    + DependOnAccountEventStore
     + DependOnPermissionChecker
 {
     fn suspend_account(
@@ -328,7 +345,7 @@ pub trait SuspendAccountUseCase:
             let mut transaction = self.database_connection().get_executor().await?;
 
             let nanoid = Nanoid::<Account>::new(account_id);
-            let account = self
+            let projection = self
                 .account_query_processor()
                 .find_by_nanoid_unfiltered(&mut transaction, &nanoid)
                 .await?
@@ -348,6 +365,10 @@ pub trait SuspendAccountUseCase:
                 }
             }
 
+            let account_id = projection.id().clone();
+            let (account, current_version) =
+                rehydrate_account(self, &mut transaction, &account_id).await?;
+
             if !account.status().is_active() {
                 return Err(
                     Report::new(KernelError::Rejected).attach_printable("Account is not active")
@@ -359,8 +380,6 @@ pub trait SuspendAccountUseCase:
                 );
             }
 
-            let account_id = account.id().clone();
-            let current_version = account.version().clone();
             self.account_command_processor()
                 .suspend(
                     &mut transaction,
@@ -380,6 +399,7 @@ impl<T> SuspendAccountUseCase for T where
     T: 'static
         + DependOnAccountCommandProcessor
         + DependOnAccountQueryProcessor
+        + DependOnAccountEventStore
         + DependOnPermissionChecker
 {
 }
@@ -390,6 +410,7 @@ pub trait UnsuspendAccountUseCase:
     + Send
     + DependOnAccountCommandProcessor
     + DependOnAccountQueryProcessor
+    + DependOnAccountEventStore
     + DependOnPermissionChecker
 {
     fn unsuspend_account(
@@ -401,7 +422,7 @@ pub trait UnsuspendAccountUseCase:
             let mut transaction = self.database_connection().get_executor().await?;
 
             let nanoid = Nanoid::<Account>::new(account_id);
-            let account = self
+            let projection = self
                 .account_query_processor()
                 .find_by_nanoid_unfiltered(&mut transaction, &nanoid)
                 .await?
@@ -414,14 +435,16 @@ pub trait UnsuspendAccountUseCase:
 
             check_permission(self, auth_account_id, &instance_moderate()).await?;
 
+            let account_id = projection.id().clone();
+            let (account, current_version) =
+                rehydrate_account(self, &mut transaction, &account_id).await?;
+
             if !account.status().is_suspended() {
                 return Err(
                     Report::new(KernelError::Rejected).attach_printable("Account is not suspended")
                 );
             }
 
-            let account_id = account.id().clone();
-            let current_version = account.version().clone();
             self.account_command_processor()
                 .unsuspend(&mut transaction, account_id, current_version)
                 .await?;
@@ -435,6 +458,7 @@ impl<T> UnsuspendAccountUseCase for T where
     T: 'static
         + DependOnAccountCommandProcessor
         + DependOnAccountQueryProcessor
+        + DependOnAccountEventStore
         + DependOnPermissionChecker
 {
 }
@@ -445,6 +469,7 @@ pub trait BanAccountUseCase:
     + Send
     + DependOnAccountCommandProcessor
     + DependOnAccountQueryProcessor
+    + DependOnAccountEventStore
     + DependOnPermissionChecker
 {
     fn ban_account(
@@ -457,7 +482,7 @@ pub trait BanAccountUseCase:
             let mut transaction = self.database_connection().get_executor().await?;
 
             let nanoid = Nanoid::<Account>::new(account_id);
-            let account = self
+            let projection = self
                 .account_query_processor()
                 .find_by_nanoid_unfiltered(&mut transaction, &nanoid)
                 .await?
@@ -470,6 +495,10 @@ pub trait BanAccountUseCase:
 
             check_permission(self, auth_account_id, &instance_moderate()).await?;
 
+            let account_id = projection.id().clone();
+            let (account, current_version) =
+                rehydrate_account(self, &mut transaction, &account_id).await?;
+
             if account.status().is_banned() {
                 return Err(Report::new(KernelError::Rejected)
                     .attach_printable("Account is already banned"));
@@ -480,8 +509,6 @@ pub trait BanAccountUseCase:
                 );
             }
 
-            let account_id = account.id().clone();
-            let current_version = account.version().clone();
             self.account_command_processor()
                 .ban(&mut transaction, account_id, reason, current_version)
                 .await?;
@@ -495,6 +522,40 @@ impl<T> BanAccountUseCase for T where
     T: 'static
         + DependOnAccountCommandProcessor
         + DependOnAccountQueryProcessor
+        + DependOnAccountEventStore
         + DependOnPermissionChecker
 {
+}
+
+async fn rehydrate_account<T>(
+    deps: &T,
+    executor: &mut <<T as kernel::interfaces::database::DependOnDatabaseConnection>::DatabaseConnection as DatabaseConnection>::Executor,
+    account_id: &AccountId,
+) -> error_stack::Result<(Account, EventVersion<Account>), KernelError>
+where
+    T: DependOnAccountEventStore + ?Sized,
+{
+    let event_id = EventId::from(account_id.clone());
+    let events = deps
+        .account_event_store()
+        .find_by_id(executor, &event_id, None)
+        .await?;
+    if events.is_empty() {
+        return Err(Report::new(KernelError::NotFound).attach_printable(format!(
+            "No events found for account: {}",
+            account_id.as_ref()
+        )));
+    }
+    let mut account: Option<Account> = None;
+    for event in events {
+        Account::apply(&mut account, event)?;
+    }
+    let account = account.ok_or_else(|| {
+        Report::new(KernelError::NotFound).attach_printable(format!(
+            "Account aggregate could not be reconstructed for: {}",
+            account_id.as_ref()
+        ))
+    })?;
+    let current_version = account.version().clone();
+    Ok((account, current_version))
 }

--- a/application/src/service/metadata.rs
+++ b/application/src/service/metadata.rs
@@ -229,6 +229,7 @@ pub trait UpdateMetadataUseCase:
     + Send
     + DependOnMetadataCommandProcessor
     + DependOnMetadataQueryProcessor
+    + DependOnMetadataEventStore
     + DependOnAccountQueryProcessor
     + DependOnPermissionChecker
 {
@@ -275,7 +276,8 @@ pub trait UpdateMetadataUseCase:
                 })?;
 
             let metadata_id = metadata.id().clone();
-            let current_version = metadata.version().clone();
+            let (_metadata, current_version) =
+                rehydrate_metadata(self, &mut transaction, &metadata_id).await?;
             self.metadata_command_processor()
                 .update(
                     &mut transaction,
@@ -299,6 +301,7 @@ impl<T> UpdateMetadataUseCase for T where
         + Send
         + DependOnMetadataCommandProcessor
         + DependOnMetadataQueryProcessor
+        + DependOnMetadataEventStore
         + DependOnAccountQueryProcessor
         + DependOnPermissionChecker
 {
@@ -311,6 +314,7 @@ pub trait DeleteMetadataUseCase:
     + DependOnMetadataCommandProcessor
     + DependOnMetadataQueryProcessor
     + DependOnAccountQueryProcessor
+    + DependOnMetadataEventStore
     + DependOnPermissionChecker
 {
     fn delete_metadata(
@@ -357,7 +361,8 @@ pub trait DeleteMetadataUseCase:
                 })?;
 
             let metadata_id = metadata.id().clone();
-            let current_version = metadata.version().clone();
+            let (_metadata, current_version) =
+                rehydrate_metadata(self, &mut transaction, &metadata_id).await?;
             self.metadata_command_processor()
                 .delete(&mut transaction, metadata_id, current_version)
                 .await?;
@@ -369,11 +374,43 @@ pub trait DeleteMetadataUseCase:
 
 impl<T> DeleteMetadataUseCase for T where
     T: 'static
-        + Sync
-        + Send
         + DependOnMetadataCommandProcessor
         + DependOnMetadataQueryProcessor
         + DependOnAccountQueryProcessor
+        + DependOnMetadataEventStore
         + DependOnPermissionChecker
 {
+}
+
+async fn rehydrate_metadata<T>(
+    deps: &T,
+    executor: &mut <<T as kernel::interfaces::database::DependOnDatabaseConnection>::DatabaseConnection as DatabaseConnection>::Executor,
+    metadata_id: &MetadataId,
+) -> error_stack::Result<(Metadata, kernel::prelude::entity::EventVersion<Metadata>), KernelError>
+where
+    T: DependOnMetadataEventStore + ?Sized,
+{
+    let event_id = EventId::from(metadata_id.clone());
+    let events = deps
+        .metadata_event_store()
+        .find_by_id(executor, &event_id, None)
+        .await?;
+    if events.is_empty() {
+        return Err(Report::new(KernelError::NotFound).attach_printable(format!(
+            "No events found for metadata: {}",
+            metadata_id.as_ref()
+        )));
+    }
+    let mut metadata: Option<Metadata> = None;
+    for event in events {
+        Metadata::apply(&mut metadata, event)?;
+    }
+    let metadata = metadata.ok_or_else(|| {
+        Report::new(KernelError::NotFound).attach_printable(format!(
+            "Metadata aggregate could not be reconstructed (already deleted?): {}",
+            metadata_id.as_ref()
+        ))
+    })?;
+    let current_version = metadata.version().clone();
+    Ok((metadata, current_version))
 }

--- a/application/src/service/profile.rs
+++ b/application/src/service/profile.rs
@@ -258,7 +258,6 @@ pub trait UpdateProfileUseCase:
                         summary: dto.summary.map(ProfileSummary::new),
                         icon,
                         banner,
-                        current_version: profile.version().clone(),
                     },
                 )
                 .await?;

--- a/kernel/src/entity/account.rs
+++ b/kernel/src/entity/account.rs
@@ -386,8 +386,7 @@ mod test {
             .id(id.clone())
             .nanoid(nano_id.clone())
             .build();
-        let version = account.version().clone();
-        let event = Account::update(id.clone(), AccountIsBot::new(true), version);
+        let event = Account::update(id.clone(), AccountIsBot::new(true), EventVersion::default());
         let envelope = EventEnvelope::new(
             event.id().clone(),
             event.event().clone(),
@@ -405,8 +404,7 @@ mod test {
     fn update_not_exist_account() {
         crate::ensure_generator_initialized();
         let id = AccountId::default();
-        let version = EventVersion::default();
-        let event = Account::update(id.clone(), AccountIsBot::new(true), version);
+        let event = Account::update(id.clone(), AccountIsBot::new(true), EventVersion::default());
         let envelope = EventEnvelope::new(
             event.id().clone(),
             event.event().clone(),

--- a/kernel/src/entity/metadata.rs
+++ b/kernel/src/entity/metadata.rs
@@ -199,9 +199,12 @@ mod test {
             .build();
         let label = MetadataLabel::new("new_label".to_string());
         let content = MetadataContent::new("new_content".to_string());
-        let current_version = metadata.version().clone();
-        let update_event =
-            Metadata::update(id.clone(), label.clone(), content.clone(), current_version);
+        let update_event = Metadata::update(
+            id.clone(),
+            label.clone(),
+            content.clone(),
+            EventVersion::default(),
+        );
         let version = EventVersion::default();
         let envelope = EventEnvelope::new(
             update_event.id().clone(),

--- a/kernel/src/entity/profile.rs
+++ b/kernel/src/entity/profile.rs
@@ -82,13 +82,13 @@ impl Profile {
         )
     }
 
+    /// Last-write-wins: no optimistic concurrency check.
     pub fn update(
         id: ProfileId,
         display_name: FieldAction<ProfileDisplayName>,
         summary: FieldAction<ProfileSummary>,
         icon: FieldAction<ImageId>,
         banner: FieldAction<ImageId>,
-        current_version: EventVersion<Profile>,
     ) -> CommandEnvelope<ProfileEvent, Profile> {
         let event = ProfileEvent::Updated {
             display_name,
@@ -96,12 +96,7 @@ impl Profile {
             icon,
             banner,
         };
-        CommandEnvelope::new(
-            EventId::from(id),
-            event.name(),
-            event,
-            Some(KnownEventVersion::Prev(current_version)),
-        )
+        CommandEnvelope::new(EventId::from(id), event.name(), event, None)
     }
 }
 
@@ -234,14 +229,12 @@ mod test {
         let summary = ProfileSummary::new("summary".to_string());
         let icon = ImageId::new(crate::generate_id());
         let banner = ImageId::new(crate::generate_id());
-        let current_version = profile.version().clone();
         let update_event = Profile::update(
             id.clone(),
             FieldAction::Set(display_name.clone()),
             FieldAction::Set(summary.clone()),
             FieldAction::Set(icon.clone()),
             FieldAction::Set(banner.clone()),
-            current_version,
         );
         let version = EventVersion::default();
         let envelope = EventEnvelope::new(
@@ -276,16 +269,13 @@ mod test {
             .icon(Some(icon))
             .banner(Some(banner))
             .build();
-        let version = profile.version().clone();
 
-        // Clear both icon and banner with FieldAction::Clear
         let update_event = Profile::update(
             id,
             FieldAction::Unchanged,
             FieldAction::Unchanged,
             FieldAction::Clear,
             FieldAction::Clear,
-            version,
         );
         let new_version = EventVersion::default();
         let envelope = EventEnvelope::new(

--- a/server/src/applier/account_applier.rs
+++ b/server/src/applier/account_applier.rs
@@ -237,6 +237,7 @@ impl AccountApplier {
                 Ok(())
             },
         );
+        queue.start_workers();
         AccountApplier(queue)
     }
 }

--- a/server/src/applier/auth_account_applier.rs
+++ b/server/src/applier/auth_account_applier.rs
@@ -26,6 +26,7 @@ impl AuthAccountApplier {
                     .map_err(|e| rikka_mq::error::ErrorOperation::Delay(format!("{:?}", e)))
             },
         );
+        queue.start_workers();
         AuthAccountApplier(queue)
     }
 }

--- a/server/src/applier/metadata_applier.rs
+++ b/server/src/applier/metadata_applier.rs
@@ -26,6 +26,7 @@ impl MetadataApplier {
                     .map_err(|e| rikka_mq::error::ErrorOperation::Delay(format!("{:?}", e)))
             },
         );
+        queue.start_workers();
         MetadataApplier(queue)
     }
 }

--- a/server/src/applier/profile_applier.rs
+++ b/server/src/applier/profile_applier.rs
@@ -26,6 +26,7 @@ impl ProfileApplier {
                     .map_err(|e| rikka_mq::error::ErrorOperation::Delay(format!("{:?}", e)))
             },
         );
+        queue.start_workers();
         ProfileApplier(queue)
     }
 }

--- a/server/tests/e2e_basic_flow.rs
+++ b/server/tests/e2e_basic_flow.rs
@@ -96,6 +96,117 @@ async fn login_create_account_and_verify_profile() {
     );
 
     assert_concurrent_account_updates_succeed(&client, &jwt, account_id).await;
+
+    assert_metadata_lifecycle(&client, &jwt, account_id).await;
+}
+
+async fn assert_metadata_lifecycle(client: &reqwest::Client, jwt: &str, account_id: &str) {
+    let create_url = format!("http://localhost:8080/accounts/{account_id}/metadata");
+    let resp = client
+        .post(&create_url)
+        .bearer_auth(jwt)
+        .json(&serde_json::json!({"label": "website", "content": "https://example.com"}))
+        .send()
+        .await
+        .expect("failed to create metadata");
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        reqwest::StatusCode::CREATED,
+        "metadata create failed: {body}"
+    );
+    let created: serde_json::Value =
+        serde_json::from_str(&body).expect("failed to parse metadata response");
+    let metadata_nanoid = created
+        .get("nanoid")
+        .and_then(|v| v.as_str())
+        .expect("metadata response missing nanoid")
+        .to_string();
+
+    let metadata = poll_metadata(client, jwt, account_id, true).await;
+    assert_eq!(metadata.len(), 1, "expected single metadata after create");
+    assert_eq!(
+        metadata[0]
+            .get("nanoid")
+            .and_then(|v| v.as_str())
+            .expect("metadata projection missing nanoid"),
+        metadata_nanoid
+    );
+
+    let resource_url =
+        format!("http://localhost:8080/accounts/{account_id}/metadata/{metadata_nanoid}");
+    let resp = client
+        .delete(&resource_url)
+        .bearer_auth(jwt)
+        .send()
+        .await
+        .expect("metadata delete failed");
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    assert_eq!(
+        status,
+        reqwest::StatusCode::NO_CONTENT,
+        "metadata delete failed: {body}"
+    );
+
+    let metadata = poll_metadata(client, jwt, account_id, false).await;
+    assert!(
+        metadata.is_empty(),
+        "metadata projection still visible after delete: {metadata:?}"
+    );
+
+    let resp = client
+        .put(&resource_url)
+        .bearer_auth(jwt)
+        .json(&serde_json::json!({"label": "website", "content": "https://other.example.com"}))
+        .send()
+        .await
+        .expect("metadata update-after-delete request failed");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "expected 404 on update-after-delete (bug 2 regression)"
+    );
+}
+
+async fn poll_metadata(
+    client: &reqwest::Client,
+    jwt: &str,
+    account_id: &str,
+    expect_present: bool,
+) -> Vec<serde_json::Value> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut attempts = 0u32;
+    loop {
+        attempts += 1;
+        let resp = client
+            .get(format!(
+                "http://localhost:8080/metadata?account_ids={account_id}"
+            ))
+            .bearer_auth(jwt)
+            .send()
+            .await
+            .expect("failed to query metadata");
+        let status = resp.status();
+        let body = resp.text().await.expect("failed to read metadata response");
+        assert_eq!(
+            status,
+            reqwest::StatusCode::OK,
+            "metadata query failed (attempt {attempts}): {body}"
+        );
+        let metadata: Vec<serde_json::Value> =
+            serde_json::from_str(&body).expect("failed to parse metadata response");
+        let has = !metadata.is_empty();
+        if has == expect_present {
+            return metadata;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for metadata projection (expect_present={expect_present}) after {attempts} attempts"
+        );
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
 }
 
 async fn assert_concurrent_account_updates_succeed(

--- a/server/tests/e2e_basic_flow.rs
+++ b/server/tests/e2e_basic_flow.rs
@@ -161,4 +161,3 @@ async fn poll_profiles(
         tokio::time::sleep(Duration::from_millis(300)).await;
     }
 }
-

--- a/server/tests/e2e_basic_flow.rs
+++ b/server/tests/e2e_basic_flow.rs
@@ -63,6 +63,63 @@ async fn login_create_account_and_verify_profile() {
             .expect("profile missing display_name"),
         "E2E Test Account"
     );
+
+    let update_url = format!("http://localhost:8080/accounts/{account_id}/profile");
+    let resp1 = client
+        .put(&update_url)
+        .bearer_auth(&jwt)
+        .json(&serde_json::json!({"display_name": "Updated Name 1"}))
+        .send()
+        .await
+        .expect("first profile update failed");
+    let status1 = resp1.status();
+    let body1 = resp1.text().await.unwrap_or_default();
+    assert_eq!(
+        status1,
+        reqwest::StatusCode::NO_CONTENT,
+        "first update failed: {body1}"
+    );
+
+    let resp2 = client
+        .put(&update_url)
+        .bearer_auth(&jwt)
+        .json(&serde_json::json!({"display_name": "Updated Name 2"}))
+        .send()
+        .await
+        .expect("second profile update failed");
+    let status2 = resp2.status();
+    let body2 = resp2.text().await.unwrap_or_default();
+    assert_eq!(
+        status2,
+        reqwest::StatusCode::NO_CONTENT,
+        "second update failed (LWW regression - version mismatch?): {body2}"
+    );
+
+    assert_concurrent_account_updates_succeed(&client, &jwt, account_id).await;
+}
+
+async fn assert_concurrent_account_updates_succeed(
+    client: &reqwest::Client,
+    jwt: &str,
+    account_id: &str,
+) {
+    let account_update_url = format!("http://localhost:8080/accounts/{account_id}");
+    for (n, expected_is_bot) in [(1u32, true), (2u32, false)] {
+        let resp = client
+            .put(&account_update_url)
+            .bearer_auth(jwt)
+            .json(&serde_json::json!({"is_bot": expected_is_bot}))
+            .send()
+            .await
+            .expect("account update failed");
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        assert_eq!(
+            status,
+            reqwest::StatusCode::NO_CONTENT,
+            "account update #{n} failed: {body}"
+        );
+    }
 }
 
 async fn poll_profiles(
@@ -104,3 +161,4 @@ async fn poll_profiles(
         tokio::time::sleep(Duration::from_millis(300)).await;
     }
 }
+


### PR DESCRIPTION
## Problem

ReadModel.version (e.g. \`profiles.version\`) lagged behind EventStore.MAX(version) because update operations only emit a Signal and update the projection asynchronously. UseCases were passing \`ReadModel.version()\` as \`prev_version\` to the optimistic-concurrency check, so a second rapid update would fail with \`KernelError::Concurrency\` against \`MAX(events.version)\`.

## Fix — Hybrid approach (per Oracle consultation)

| Operation | Strategy | Reason |
|---|---|---|
| \`Profile.update\` | **LWW** (\`prev_version=None\`) | Pure patch semantics, no state machine |
| \`Account.update\` (is_bot) | **Rehydrate** | Must respect suspend/ban/deactivate state |
| \`Metadata.update\` | **Rehydrate** | Must reject update-after-delete (Metadata::apply panics on Updated→None) |
| \`Account.deactivate/suspend/unsuspend/ban\` | **Rehydrate** | State machine transitions |
| \`Metadata.delete\` | **Rehydrate** | State machine transition |

Rehydrate path reads from EventStore via \`find_by_id\` + \`apply\` loop, giving authoritative \`current_version\` AND domain state for permission/status checks. ReadModel projection still used for \`nanoid → id\` mapping and permission lookups.

## Verification

- \`cargo check --workspace\`: clean
- \`cargo test -p kernel\`: 24 passed
- \`just e2e\`: passed — \`PUT /accounts/{nanoid}/profile\` and \`PUT /accounts/{nanoid}\` twice in rapid succession both return 204 (previously: second call → 500 Concurrency)

## Files

9 files, +192/-49. Kernel entities, adapter Params, application UseCases, E2E regression test.